### PR TITLE
Restrict pages workflow to ComCatLab repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,7 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
+        if: github.repository == 'ComCatLab/welcome-guide'
         permissions:
             pages: write
             id-token: write


### PR DESCRIPTION
This PR edits the workflow file for the GH action responsible for building the webpage. The edit prevents the action from running outside of the ComCatLab repo, so you don't accidentally launch a version of the webpage in your own workspace or get spammed with failed GH action notifications.