### PR TITLE
Fix import command

### DIFF
--- a/docs/sources/onboarding/basic_setup.md
+++ b/docs/sources/onboarding/basic_setup.md
@@ -127,7 +127,7 @@ or Python; however, the following reference pages may be of use:
     (TODO: add screenshot of Python interpreter)
 
     ```python
-    import ase, matplotlib, ruff, pymatgen, matplotlib, mp-api
+    import ase, matplotlib, ruff, pymatgen, matplotlib, mp_api
     ```
 
     If this command fails, then something went wrong with the `pip` command


### PR DESCRIPTION
The import command failed due to the hyphen instead of the underscore in `mp-api`